### PR TITLE
Fixes application error

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -50,7 +50,7 @@ const processEsResponse = results =>
 
 router.get('/search-results', function(req, res, next) {
   const query = req.query.q
-  const orgTypes = req.query['org-type']
+  const orgTypes = req.query['org-type'] || ''
   const sortBy = req.query['sortby']
   const location = req.query['location']
 

--- a/app/views/search-results.html
+++ b/app/views/search-results.html
@@ -33,7 +33,7 @@
             <h2 class="heading-medium first-filter">Sort by</h2>
             <legend class="visually-hidden">Sort by</legend>
             <div class="multiple-choice">
-              <input id="sortby-best" type="radio" name="sortby" value="best" {{ "checked" if sortBy == "best" else "" }}>
+              <input id="sortby-best" type="radio" name="sortby" value="best" {{ "checked" if (sortBy == "best" or sortBy == "") else "" }}>
               <label for="sortby-best">Best match</label>
             </div>
             <div class="multiple-choice">


### PR DESCRIPTION
Fixes the search-result route so that it doesn't crash if no org-type is
provided as a query param (which is then used to provide some context to
the template).

Also, makes Best match the default value in the template if there is a
search term. Most recent should probably be the default when there is no
search term.

Fixes #31