### PR TITLE
Do not show empty search term if there is no search term

### DIFF
--- a/app/views/search-results.html
+++ b/app/views/search-results.html
@@ -21,7 +21,7 @@
   </div>
   <div class="grid-row">
     <div class="column-two-thirds">
-      <span class="bold-small">{{ numResults }}</span> results found for <span class="bold-small">'{{ query }}'</span>
+      <span class="bold-small">{{ numResults }}</span> results found {% if query %}for <span class="bold-small">'{{ query }}'{% endif%}</span>
     </div>
   </div>
   <div class="grid-row">


### PR DESCRIPTION
When doing an empty search, it said
     X results found for '' 

Removed the "for ''"" when it is an empty search